### PR TITLE
Fix CSP

### DIFF
--- a/uofi-itp-directory/Pages/_Host.cshtml
+++ b/uofi-itp-directory/Pages/_Host.cshtml
@@ -21,11 +21,11 @@
     <script src="js/default.js"></script>
     <meta http-equiv="Content-Security-Policy" content="
         base-uri 'self';
-        default-src 'self' illinois.edu *.illinois.edu *.quill.com;
+        default-src 'self' illinois.edu *.illinois.edu *.quilljs.com;
         img-src data: https:;
         object-src 'none';
-        script-src 'self' 'wasm-unsafe-eval' 'unsafe-hashes' 'sha256-qnHnQs7NjQNHHNYv/I9cW+I62HzDJjbnyS/OFzqlix0=' illinois.edu *.illinois.edu *.quill.com 'unsafe-inline';
-        style-src https: illinois.edu *.illinois.edu *.quill.com 'unsafe-inline';
+        script-src 'self' 'wasm-unsafe-eval' 'unsafe-hashes' 'sha256-qnHnQs7NjQNHHNYv/I9cW+I62HzDJjbnyS/OFzqlix0=' illinois.edu *.illinois.edu *.quilljs.com 'unsafe-inline';
+        style-src https: illinois.edu *.illinois.edu *.quilljs.com 'unsafe-inline';
         connect-src 'self' http: ws: wss:;
         upgrade-insecure-requests;" />
     <component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />


### PR DESCRIPTION
This pull request updates the Content Security Policy (CSP) in the `_Host.cshtml` file to use the correct domain for Quill resources. The changes ensure that resources are loaded from `quilljs.com` instead of the incorrect `quill.com` domain.

Security and resource domain updates:

* Updated the `default-src`, `script-src`, and `style-src` CSP directives to allow resources from `*.quilljs.com` instead of `*.quill.com`, ensuring compatibility with Quill's actual CDN and improving security.