### PR TITLE
Fix automatic keyword reader in directory

### DIFF
--- a/uofi-itp-directory-external/Experts/KeywordReader.cs
+++ b/uofi-itp-directory-external/Experts/KeywordReader.cs
@@ -6,18 +6,17 @@ namespace uofi_itp_directory_external.Experts {
         private static readonly int _maximumItemsToPull = 10;
 
         public static async Task<List<string>> AddKeywords(string expertsId, string url, string apikey) {
-            var keywordList = new List<string>();
+            var returnValue = new List<string>();
             dynamic experts = await ReaderHelper.GetItem($"{url}persons/{expertsId}/fingerprints?size=10&apiKey={apikey}");
             var fingerprints = JsonConvert.DeserializeObject(experts);
-            var returnValue = new List<string>();
             var items = fingerprints.items;
             foreach (var item in items) {
                 var concepts = item.concepts;
                 foreach (var concept in concepts) {
                     dynamic expertsConcepts = await ReaderHelper.GetItem($"{url}concepts/{concept.uuid}?apiKey={apikey}");
                     var conceptText = JsonConvert.DeserializeObject(expertsConcepts);
-                    keywordList.Add(conceptText.name.text[0].value.ToString());
-                    if (keywordList.Count >= _maximumItemsToPull) {
+                    returnValue.Add(conceptText.name.text[0].value.ToString());
+                    if (returnValue.Count >= _maximumItemsToPull) {
                         break;
                     }
                 }


### PR DESCRIPTION
This pull request makes a small update to the `KeywordReader` class to clean up variable usage. The redundant `keywordList` variable is removed, and all keyword collection is now handled by the `returnValue` list, improving code clarity and maintainability.

- Refactored the `AddKeywords` method in `KeywordReader.cs` to eliminate the unused `keywordList` variable and use `returnValue` consistently for collecting and returning keywords.