### PR TITLE
Add clear load

### DIFF
--- a/uofi-itp-directory-data/DirectoryHook/QueueManager.cs
+++ b/uofi-itp-directory-data/DirectoryHook/QueueManager.cs
@@ -26,5 +26,10 @@ namespace uofi_itp_directory_data.DirectoryHook {
                 }
             }
         }
+
+        public async Task<string> Clear() {
+            var items = await _directoryHookHelper.LoadAreas();
+            return $"Queue is being emptied. Adding {items} names to queue.";
+        }
     }
 }

--- a/uofi-itp-directory-function/LoadFunction.cs
+++ b/uofi-itp-directory-function/LoadFunction.cs
@@ -1,4 +1,3 @@
-using System.Net;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
@@ -6,6 +5,7 @@ using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
+using System.Net;
 using uofi_itp_directory_data.DirectoryHook;
 using uofi_itp_directory_function.Helpers;
 using uofi_itp_directory_search.LoadHelper;
@@ -16,6 +16,12 @@ namespace uofi_itp_directory_function {
         private readonly LoadManager _loadManager = loadManager;
         private readonly ILogger<LoadFunction> _logger = logger;
         private readonly QueueManager _queueManager = queueManager;
+
+        [Function("ClearLoadProcess")]
+        [OpenApiOperation(operationId: "Clear Load Process", tags: "Load", Description = "Clear the load process to restart it. Used if you need to refresh from scratch.")]
+        [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "text/plain", bodyType: typeof(string), Description = "A status of what it did.")]
+        public async Task<IActionResult> ClearLoadProcess([HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = "Load")] HttpRequest req) =>
+            LogAndReturn(await _queueManager.Clear());
 
         [Function("LoadPersonAutomatically")]
         [OpenApiOperation(operationId: "Load Person Automatically", tags: "Load", Description = "Load a person using the default parameters and source information. Note that this account has to be listed as using the default load for this to work properly.")]


### PR DESCRIPTION
This pull request introduces a new API endpoint to allow clearing and restarting the load process from scratch, along with a minor code cleanup. The main focus is on adding the ability to reset the queue via a new function.

### New API functionality

* Added a new `ClearLoadProcess` Azure Function endpoint to `LoadFunction`, which allows users to clear the current load process and restart it. This endpoint is documented with OpenAPI attributes and returns a status message.
* Implemented a new `Clear` method in `QueueManager` that loads the relevant items and returns a message indicating the queue is being emptied.

### Code cleanup

* Moved the `using System.Net;` directive lower in `LoadFunction.cs` to follow code style conventions.