### PR TITLE
Alter csp

### DIFF
--- a/uofi-itp-directory/Pages/_Host.cshtml
+++ b/uofi-itp-directory/Pages/_Host.cshtml
@@ -21,11 +21,11 @@
     <script src="js/default.js"></script>
     <meta http-equiv="Content-Security-Policy" content="
         base-uri 'self';
-        default-src 'self' illinois.edu *.illinois.edu *.quilljs.com;
+        default-src 'self' illinois.edu *.illinois.edu *.quilljs.com *.jsdelivr.net;
         img-src data: https:;
         object-src 'none';
-        script-src 'self' 'wasm-unsafe-eval' 'unsafe-hashes' 'sha256-qnHnQs7NjQNHHNYv/I9cW+I62HzDJjbnyS/OFzqlix0=' illinois.edu *.illinois.edu *.quilljs.com 'unsafe-inline';
-        style-src https: illinois.edu *.illinois.edu *.quilljs.com 'unsafe-inline';
+        script-src 'self' 'wasm-unsafe-eval' 'unsafe-hashes' 'sha256-qnHnQs7NjQNHHNYv/I9cW+I62HzDJjbnyS/OFzqlix0=' illinois.edu *.illinois.edu *.quilljs.com *.jsdelivr.net 'unsafe-inline';
+        style-src https: illinois.edu *.illinois.edu *.quilljs.com *.jsdelivr.net 'unsafe-inline';
         connect-src 'self' http: ws: wss:;
         upgrade-insecure-requests;" />
     <component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />


### PR DESCRIPTION
This pull request updates the Content Security Policy (CSP) in the `_Host.cshtml` file to allow resources from the `jsdelivr.net` CDN. This change enables the application to load scripts and styles from `*.jsdelivr.net`, which may be required for new or updated dependencies.

**Content Security Policy updates:**

* Added `*.jsdelivr.net` to the `default-src`, `script-src`, and `style-src` directives in the CSP meta tag in `_Host.cshtml` to permit loading scripts and styles from this CDN.