### PR TITLE
Changing SearchStaxHelper to singleton

### DIFF
--- a/uofi-itp-directory-function/Program.cs
+++ b/uofi-itp-directory-function/Program.cs
@@ -45,7 +45,7 @@ var host = new HostBuilder()
         _ = services.AddScoped(c => new DirectoryHookHelper(c.GetService<DirectoryRepository>(), hostContext.Configuration["Values:FacultyLoadUrl"]));
         _ = services.AddScoped(c => new EmployeeHelper(c.GetService<DirectoryRepository>(), null, c.GetService<DirectoryContext>(), c.GetService<EmployeeAreaHelper>(), c.GetService<LogHelper>()));
         _ = services.AddScoped<QueueManager>();
-        _ = services.AddScoped(c => new SearchStaxLoader(hostContext.Configuration["Values:SearchStaxUrl"], hostContext.Configuration["Values:SearchStaxApiToken"]));
+        _ = services.AddSingleton(c => new SearchStaxLoader(hostContext.Configuration["Values:SearchStaxUrl"], hostContext.Configuration["Values:SearchStaxApiToken"]));
         _ = services.AddScoped(c => new DataWarehouseManager(hostContext.Configuration["Values:DataWarehouseUrl"], hostContext.Configuration["Values:DataWarehouseKey"]));
         _ = services.AddScoped(c => new IllinoisExpertsManager(hostContext.Configuration["Values:ExpertsUrl"], hostContext.Configuration["Values:ExpertsSecretKey"]));
         _ = services.AddScoped(c => new ProgramCourseInformation(hostContext.Configuration["Values:ProgramCourseUrl"]));


### PR DESCRIPTION
This pull request makes a change to the dependency injection configuration in `Program.cs` to improve the lifecycle management of the `SearchStaxLoader` service.

Dependency injection improvements:

* Changed the registration of `SearchStaxLoader` from `AddScoped` to `AddSingleton`, ensuring a single instance is used throughout the application's lifetime. This can improve performance and resource usage when the service is stateless or expensive to initialize.