### PR TITLE
Converting datawarehouse and experts to singleton.

### DIFF
--- a/uofi-itp-directory-function/Program.cs
+++ b/uofi-itp-directory-function/Program.cs
@@ -46,8 +46,8 @@ var host = new HostBuilder()
         _ = services.AddScoped(c => new EmployeeHelper(c.GetService<DirectoryRepository>(), null, c.GetService<DirectoryContext>(), c.GetService<EmployeeAreaHelper>(), c.GetService<LogHelper>()));
         _ = services.AddScoped<QueueManager>();
         _ = services.AddSingleton(c => new SearchStaxLoader(hostContext.Configuration["Values:SearchStaxUrl"], hostContext.Configuration["Values:SearchStaxApiToken"]));
-        _ = services.AddScoped(c => new DataWarehouseManager(hostContext.Configuration["Values:DataWarehouseUrl"], hostContext.Configuration["Values:DataWarehouseKey"]));
-        _ = services.AddScoped(c => new IllinoisExpertsManager(hostContext.Configuration["Values:ExpertsUrl"], hostContext.Configuration["Values:ExpertsSecretKey"]));
+        _ = services.AddSingleton(c => new DataWarehouseManager(hostContext.Configuration["Values:DataWarehouseUrl"], hostContext.Configuration["Values:DataWarehouseKey"]));
+        _ = services.AddSingleton(c => new IllinoisExpertsManager(hostContext.Configuration["Values:ExpertsUrl"], hostContext.Configuration["Values:ExpertsSecretKey"]));
         _ = services.AddScoped(c => new ProgramCourseInformation(hostContext.Configuration["Values:ProgramCourseUrl"]));
         _ = services.AddScoped(c => new PersonGetter(c.GetService<OpenSearchLowLevelClient>()));
         _ = services.AddScoped(c => new PersonSetter(hostContext.Configuration["Values:SearchUrl"] ?? "", c.GetService<OpenSearchLowLevelClient>(), Console.WriteLine));


### PR DESCRIPTION
This pull request updates the dependency injection lifetimes of the `DataWarehouseManager` and `IllinoisExpertsManager` services in `Program.cs` to use singleton scope instead of scoped. This means only one instance of each manager will be created and shared throughout the application's lifetime, rather than creating a new instance per request.

Dependency injection lifetime changes:

* Changed `DataWarehouseManager` registration from scoped to singleton, ensuring a single instance is used application-wide.
* Changed `IllinoisExpertsManager` registration from scoped to singleton, ensuring a single instance is used application-wide.